### PR TITLE
Set up Amazon SES SMTP credentials and methods to send emails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>spring-boot-starter-validation</artifactId>
             <version>2.6.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>

--- a/src/main/java/ag04/project/moneyheist/Mail/Config.java
+++ b/src/main/java/ag04/project/moneyheist/Mail/Config.java
@@ -1,0 +1,31 @@
+package ag04.project.moneyheist.Mail;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class Config {
+
+    @Bean
+    public JavaMailSender getJavaMailSender(@Value("${spring.mail.username}") String username,
+                                            @Value("${spring.mail.password}") String password) {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("email-smtp.eu-central-1.amazonaws.com");
+        mailSender.setPort(587);
+
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.starttls.enable", "true");
+
+        return mailSender;
+    }
+}

--- a/src/main/java/ag04/project/moneyheist/Mail/EmailService.java
+++ b/src/main/java/ag04/project/moneyheist/Mail/EmailService.java
@@ -1,0 +1,6 @@
+package ag04.project.moneyheist.Mail;
+
+public interface EmailService {
+
+    void sendSimpleMessage(String to, String subject, String text);
+}

--- a/src/main/java/ag04/project/moneyheist/Mail/EmailServiceImpl.java
+++ b/src/main/java/ag04/project/moneyheist/Mail/EmailServiceImpl.java
@@ -1,0 +1,25 @@
+package ag04.project.moneyheist.Mail;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmailServiceImpl implements EmailService {
+    private final JavaMailSender emailSender;
+
+    @Autowired
+    public EmailServiceImpl(JavaMailSender emailSender) {
+        this.emailSender = emailSender;
+    }
+
+    public void sendSimpleMessage(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom("hana.hrustic@gmail.com");
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+        emailSender.send(message);
+    }
+}

--- a/src/main/java/ag04/project/moneyheist/services/MemberHeistServiceImpl.java
+++ b/src/main/java/ag04/project/moneyheist/services/MemberHeistServiceImpl.java
@@ -1,5 +1,6 @@
 package ag04.project.moneyheist.services;
 
+import ag04.project.moneyheist.Mail.EmailService;
 import ag04.project.moneyheist.domain.Heist;
 import ag04.project.moneyheist.domain.Member;
 import ag04.project.moneyheist.domain.MemberHeist;
@@ -14,10 +15,12 @@ import java.util.List;
 @Service
 public class MemberHeistServiceImpl implements MemberHeistService {
     private final MemberHeistRepository memberHeistRepository;
+    private final EmailService emailService;
 
     @Autowired
-    public MemberHeistServiceImpl(MemberHeistRepository memberHeistRepository) {
+    public MemberHeistServiceImpl(MemberHeistRepository memberHeistRepository, EmailService emailService) {
         this.memberHeistRepository = memberHeistRepository;
+        this.emailService = emailService;
     }
 
     @Override
@@ -26,6 +29,8 @@ public class MemberHeistServiceImpl implements MemberHeistService {
         members.forEach(member -> {
             if (member.getMemberHeists().size() == 0) {
                 memberHeist.add(new MemberHeist(member, heist));
+                emailService.sendSimpleMessage(member.getEmail(), "ADDED TO HEIST",
+                        "You have been added to a heist.");
             } else {
                 throw new BadRequest("Member has already been confirmed on another heist!");
             }

--- a/src/main/java/ag04/project/moneyheist/services/MemberServiceImpl.java
+++ b/src/main/java/ag04/project/moneyheist/services/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package ag04.project.moneyheist.services;
 
+import ag04.project.moneyheist.Mail.EmailService;
 import ag04.project.moneyheist.api.DTO.MemberDTO;
 import ag04.project.moneyheist.api.command.MemberCommand;
 import ag04.project.moneyheist.api.converter.MemberCommandToMember;
@@ -24,14 +25,16 @@ public class MemberServiceImpl implements MemberService {
     private final MemberToMemberDTO memberToMemberDTO;
     private final SkillService skillService;
     private final MemberSkillService memberSkillService;
+    private final EmailService emailService;
 
     @Autowired
-    public MemberServiceImpl(MemberRepository memberRepository, MemberCommandToMember memberCommandToMember, MemberToMemberDTO memberToMemberDTO, SkillService skillService, MemberSkillService memberSkillService) {
+    public MemberServiceImpl(MemberRepository memberRepository, MemberCommandToMember memberCommandToMember, MemberToMemberDTO memberToMemberDTO, SkillService skillService, MemberSkillService memberSkillService, EmailService emailService) {
         this.memberRepository = memberRepository;
         this.memberCommandToMember = memberCommandToMember;
         this.memberToMemberDTO = memberToMemberDTO;
-        this.memberSkillService = memberSkillService;
         this.skillService = skillService;
+        this.memberSkillService = memberSkillService;
+        this.emailService = emailService;
     }
 
     @Override
@@ -57,6 +60,9 @@ public class MemberServiceImpl implements MemberService {
         Member savedMember = memberRepository.save(memberToSave);
 
         memberSkillService.save(savedMember);
+
+        emailService.sendSimpleMessage(savedMember.getEmail(), "ADDED TO DATABASE",
+                "You have been added to participate in a possible future heists.");
 
         return memberToMemberDTO.convert(savedMember);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,9 @@
 spring.h2.console.enabled=true
 spring.datasource.url=jdbc:h2:mem:moneyheist
 spring.jpa.show-sql=true
+spring.mail.host=email-smtp.eu-central-1.amazonaws.com
+spring.mail.port=587
+spring.mail.username=AKIAR3LGX7WKEEYO2DH2
+spring.mail.password=BLmNip3B9svb0oVuTspkQ2Dp1TbFJ3PHHSI7l+crWx8s
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/test/java/ag04/project/moneyheist/services/HeistServiceImplTest.java
+++ b/src/test/java/ag04/project/moneyheist/services/HeistServiceImplTest.java
@@ -1,5 +1,6 @@
 package ag04.project.moneyheist.services;
 
+import ag04.project.moneyheist.Mail.EmailService;
 import ag04.project.moneyheist.api.converter.HeistCommandToHeist;
 import ag04.project.moneyheist.api.converter.HeistSkillToHeistSkillDTO;
 import ag04.project.moneyheist.api.converter.HeistToHeistDTO;
@@ -44,12 +45,14 @@ class HeistServiceImplTest {
     MemberToMemberDTO memberToMemberDTO;
     @Mock
     MemberHeistService memberHeistService;
+    @Mock
+    EmailService emailService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
 
-        heistService = new HeistServiceImpl(heistRepository, heistCommandToHeist, heistToHeistDTO, skillService, heistSkillService, memberService, heistSkillToHeistSkillDTO, memberToMemberDTO, memberHeistService);
+        heistService = new HeistServiceImpl(heistRepository, heistCommandToHeist, heistToHeistDTO, skillService, heistSkillService, memberService, heistSkillToHeistSkillDTO, memberToMemberDTO, memberHeistService, emailService);
     }
 
     @Test

--- a/src/test/java/ag04/project/moneyheist/services/MemberServiceImplTest.java
+++ b/src/test/java/ag04/project/moneyheist/services/MemberServiceImplTest.java
@@ -1,5 +1,6 @@
 package ag04.project.moneyheist.services;
 
+import ag04.project.moneyheist.Mail.EmailService;
 import ag04.project.moneyheist.api.command.MemberCommand;
 import ag04.project.moneyheist.api.command.SkillCommand;
 import ag04.project.moneyheist.api.converter.MemberCommandToMember;
@@ -39,11 +40,14 @@ class MemberServiceImplTest {
     @Mock
     MemberSkillService memberSkillService;
 
+    @Mock
+    EmailService emailService;
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
 
-        memberService = new MemberServiceImpl(memberRepository, memberCommandToMember, memberToMemberDTO, skillService, memberSkillService);
+        memberService = new MemberServiceImpl(memberRepository, memberCommandToMember, memberToMemberDTO, skillService, memberSkillService, emailService);
     }
 
     @Test


### PR DESCRIPTION
Send emails to notify members when added to database, confirm to be apart of a heist, when heist starts and finishes.